### PR TITLE
Fix AlreadyLoggedIn isn't raised even if session is created

### DIFF
--- a/fapi/foxford_api.py
+++ b/fapi/foxford_api.py
@@ -180,7 +180,7 @@ class Foxford_API_Sync:
                 - `UnknwonError`: Если произошла непредвиденная ошибка.
         """
         if self.session is not None:
-            AlreadyLoggedIn
+            raise AlreadyLoggedIn
         chrome_options = ChromeOptions()
         driver= Chrome(
             options = chrome_options,

--- a/fapi/foxford_api.py
+++ b/fapi/foxford_api.py
@@ -266,7 +266,7 @@ class Foxford_API_Sync:
                 - `UnknwonError`: Если произошла непредвиденная ошибка.
         """
         if self.session is not None:
-            AlreadyLoggedIn
+            raise AlreadyLoggedIn
         chrome_options = ChromeOptions()
         driver= Chrome(
             options = chrome_options,


### PR DESCRIPTION
According to docstrings, AlreadyLoggedIn should be raised when session is created. But there's missing `raise` keyword in the code. This pull request fixes that.